### PR TITLE
Shebang fix, support both py2 and 3: verify_eol

### DIFF
--- a/buildscripts/verify_eol.py
+++ b/buildscripts/verify_eol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
The purpose of the whole port to python 3 is to support MakeHuman on more platforms, not less.
Because we will be providing backward compatibility with python 2.7, the shebang should not indicate either python 2 or 3 (otherwise it will fail to run on systems that have only one of the two installed).